### PR TITLE
Fix problem with parsing dimension and media expressions

### DIFF
--- a/dist/_include-media.scss
+++ b/dist/_include-media.scss
@@ -193,7 +193,7 @@ $unit-intervals: (
   $parsed-dimension: str-slice($expression, 0, $operator-index - 1);
   $dimension: 'width';
 
-  @if str-length($parsed-dimension) {
+  @if str-length($parsed-dimension) > 0 {
     $dimension: $parsed-dimension;
   }
 

--- a/src/_config.scss
+++ b/src/_config.scss
@@ -34,14 +34,8 @@ $media-expressions: (
   'handheld': 'handheld',
   'landscape': '(orientation: landscape)',
   'portrait': '(orientation: portrait)',
-  'retina2x': (
-    '(-webkit-min-device-pixel-ratio: 2)',
-    '(min-resolution: 192dpi)'
-  ), 
-  'retina3x': (
-    '(-webkit-min-device-pixel-ratio: 3)',
-    '(min-resolution: 350dpi)'
-  )
+  'retina2x': '(-webkit-min-device-pixel-ratio: 2) (min-resolution: 192dpi)',
+  'retina3x': '(-webkit-min-device-pixel-ratio: 3), (min-resolution: 350dpi)'
 ) !default;
 
 ///

--- a/src/helpers/_outputter.scss
+++ b/src/helpers/_outputter.scss
@@ -14,7 +14,7 @@
   @if length($queries) == 0 {
     @content;
   } @else {
-    @media #{inspect(nth($queries, 1))} {
+    @media #{inspect(unquote(nth($queries, 1)))} {
       // Recursive call
       @include outputter(slice($queries, 2)) {
         @content;

--- a/src/helpers/_parser.scss
+++ b/src/helpers/_parser.scss
@@ -38,7 +38,7 @@
   $parsed-dimension: str-slice($expression, 0, $operator-index - 1);
   $dimension: 'width';
 
-  @if str-length($parsed-dimension) {
+  @if str-length($parsed-dimension) > 0 {
     $dimension: $parsed-dimension;
   }
 


### PR DESCRIPTION
SCSS:
```scss
@include media('>phone', '<tablet') {
  color: tomato;
}
```

Resulting CSS:
```css
@media (min-: 321px) and (max-: 767px) {
  color: tomato;
}
```

@HugoGiraudel this little fix seems to do it.