### PR TITLE
Allow regular query strings as argument

### DIFF
--- a/dist/_include-media.scss
+++ b/dist/_include-media.scss
@@ -268,12 +268,7 @@ $im-no-media-expressions: ('screen', 'portrait', 'landscape') !default;
     }
   }
 
-  // It is not possible to include a mixin inside a function, so we have to
-  // rely on the `log(..)` function rather than the `log(..)` mixin. Because
-  // functions cannot be called anywhere in Sass, we need to hack the call in
-  // a dummy variable, such as `$_`. If anybody ever raise a scoping issue with
-  // Sass 3.3, change this line in `@if log(..) {}` instead.
-  $_: log('No operator found in `#{$expression}`.');
+  @return false;
 }
 
 
@@ -364,6 +359,13 @@ $im-no-media-expressions: ('screen', 'portrait', 'landscape') !default;
   }
 
   $operator: get-expression-operator($expression);
+  
+  // If the expression is not part of $media-expression and has no operator,
+  // assume it is already a regular media query string
+  @if ($operator == false) {
+    @return $expression;
+  }
+  
   $dimension: get-expression-dimension($expression, $operator);
   $prefix: get-expression-prefix($operator);
   $value: get-expression-value($expression, $operator);

--- a/src/helpers/_parser.scss
+++ b/src/helpers/_parser.scss
@@ -19,12 +19,7 @@
     }
   }
 
-  // It is not possible to include a mixin inside a function, so we have to
-  // rely on the `log(..)` function rather than the `log(..)` mixin. Because
-  // functions cannot be called anywhere in Sass, we need to hack the call in
-  // a dummy variable, such as `$_`. If anybody ever raise a scoping issue with
-  // Sass 3.3, change this line in `@if log(..) {}` instead.
-  $_: log('No operator found in `#{$expression}`.');
+  @return false;
 }
 
 
@@ -115,6 +110,13 @@
   }
 
   $operator: get-expression-operator($expression);
+  
+  // If the expression is not part of $media-expression and has no operator,
+  // assume it is already a regular media query string
+  @if ($operator == false) {
+    @return $expression;
+  }
+  
   $dimension: get-expression-dimension($expression, $operator);
   $prefix: get-expression-prefix($operator);
   $value: get-expression-value($expression, $operator);


### PR DESCRIPTION
This makes include-media usable with [Foundation media queries](http://foundation.zurb.com/docs/media-queries.html) or any other predefined query strings.

Foundation comes with it’s own framework of media queries which look like this:
```sass
$small-breakpoint:  em-calc(640)  !default;
$medium-breakpoint: em-calc(1024) !default;

$medium-range:  ($small-breakpoint  + em-calc(1), $medium-breakpoint) !default; /* 641px, 1024px */

$medium-up: "#{$screen} and (min-width:#{lower-bound($medium-range)})" !default;
$medium-only: "#{$screen} and (min-width:#{lower-bound($medium-range)}) and (max-width:#{upper-bound($medium-range)})" !default;
```
Converting those into include-media’s expression syntax would result in a lot of redundant and error-prone sass code – so I thought it would be good to be able to pass variables like `$medium-up` to include-media:

```sass
.foo {
  @include media($medium-up) {
    // styles go here
  }
}
```

My quick-and-dirty approach takes anything as a regular query string that neither is an expression part of `$media-expressions` nor has a leading operator.