### PR TITLE
Fix broken media-context mixin

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "include-media",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "homepage": "https://github.com/eduardoboucas/import-media",
   "authors": [
     "Eduardo Boucas <mail@eduardoboucas.com>"

--- a/dist/_include-media.scss
+++ b/dist/_include-media.scss
@@ -8,7 +8,7 @@
 //    |_|_| |_|\___|_|\__,_|\__,_|\___| |_| |_| |_|\___|\__,_|_|\__,_|
 //
 //      Simple, elegant and maintainable media queries in Sass
-//                        v1.4.1
+//                        v1.4.2
 //
 //                http://include-media.com
 //
@@ -235,6 +235,7 @@ $im-no-media-expressions: ('screen', 'portrait', 'landscape') !default;
       $prefix: get-expression-prefix($operator);
       $value: get-expression-value($condition, $operator);
 
+      // scss-lint:disable SpaceAroundOperator
       @if ($prefix == 'max' and $value <= $no-media-breakpoint-value) or
           ($prefix == 'min' and $value > $no-media-breakpoint-value) {
         @return false;
@@ -512,7 +513,7 @@ $im-no-media-expressions: ('screen', 'portrait', 'landscape') !default;
 
   // Restore global configuration
   $breakpoints: $global-breakpoints !global;
-  $media-expressions: $tweak-media-expressions !global;
+  $media-expressions: $global-media-expressions !global;
 }
 
 ////
@@ -546,6 +547,7 @@ $im-no-media-expressions: ('screen', 'portrait', 'landscape') !default;
 ///  @include media('>=350px', '<tablet', 'retina3x') { }
 ///
 @mixin media($conditions...) {
+  // scss-lint:disable SpaceAroundOperator
   @if ($im-media-support and length($conditions) == 0) or
       (not $im-media-support and im-intercepts-static-breakpoint($conditions...)) {
     @content;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "title": "include-media",
   "name": "include-media",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Simple, elegant and maintainable media queries in Sass",
   "repository": {
     "type": "git",

--- a/src/_media.scss
+++ b/src/_media.scss
@@ -29,6 +29,7 @@
 ///  @include media('>=350px', '<tablet', 'retina3x') { }
 ///
 @mixin media($conditions...) {
+  // scss-lint:disable SpaceAroundOperator
   @if ($im-media-support and length($conditions) == 0) or
       (not $im-media-support and im-intercepts-static-breakpoint($conditions...)) {
     @content;

--- a/src/helpers/_no-media.scss
+++ b/src/helpers/_no-media.scss
@@ -18,6 +18,7 @@
       $prefix: get-expression-prefix($operator);
       $value: get-expression-value($condition, $operator);
 
+      // scss-lint:disable SpaceAroundOperator
       @if ($prefix == 'max' and $value <= $no-media-breakpoint-value) or
           ($prefix == 'min' and $value > $no-media-breakpoint-value) {
         @return false;

--- a/src/plugins/_tweakpoints.scss
+++ b/src/plugins/_tweakpoints.scss
@@ -49,5 +49,5 @@
 
   // Restore global configuration
   $breakpoints: $global-breakpoints !global;
-  $media-expressions: $tweak-media-expressions !global;
+  $media-expressions: $global-media-expressions !global;
 }

--- a/tests/helpers/_SassyTester.scss
+++ b/tests/helpers/_SassyTester.scss
@@ -11,7 +11,7 @@
 ///   * `pass`: number of passing tests out of `length`
 ///   * `fail`: number of failing tests out of `length`
 ///   * `tests`: list of maps containing:
-///       * `input`: test input (key from `$tests`) 
+///       * `input`: test input (key from `$tests`)
 ///       * `expected`: expected result from `input`
 ///       * `actual`: actual result from `input`
 ///       * `pass`: whether the test passed or not
@@ -65,7 +65,7 @@
       $passing-tests: $passing-tests + 1;
     }
   }
-  
+
   @return (
     'function': $function,
     'length': length($tests),
@@ -78,7 +78,7 @@
 
 
 /// Mixin decorating the result of `test(..)` function to throw it as an error
-/// 
+///
 /// @author Hugo Giraudel
 ///
 /// @param {Map} $data - Return of `test(..)` function
@@ -111,8 +111,9 @@
     $input: map-get($test, 'input');
 
     @if not map-get($test, 'pass') {
+      // scss-lint:disable SpaceAfterVariableName SpaceAroundOperator
       $output: $output
-        + $line-break 
+        + $line-break
         + $line-break
         + $indent
         + '✘ Test with input `#{$input}` failed dramatically.'
@@ -129,10 +130,10 @@
 
   @if str-length($output) > 0 {
     $fails: map-get($data, 'fail');
-
+    // scss-lint:disable SpaceAroundOperator
     $output: $output
-      + $line-break 
-      + $line-break 
+      + $line-break
+      + $line-break
       + $indent
       + '✘ Oops! #{$fails} test(s) failed out of #{$length} regarding `#{$function}` function.'
       + $line-break


### PR DESCRIPTION
Hey, I've found the bug in `src/plugins/_tweakpoints.scss`. 

I also added a few `scss-lint:disable` to satisfy pre-commit hooks.