### PR TITLE
Make @import 'include-media'; possible

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,9 @@
+var path = require('path');
+var package = require('./package.json');
+
+var entryPoint = require.resolve(package.name);
+var distPath = path.join(path.dirname(entryPoint), 'dist');
+
+module.exports = {
+    includePath: distPath
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/eduardoboucas/include-media.git"
   },
-  "main": "dist/_include-media.scss",
+  "main": "index.js",
   "author": {
     "name": "Eduardo Boucas",
     "email": "mail@eduardoboucas.com"


### PR DESCRIPTION
This PR is related to #108.

It adds an `index.js` file that basically returns the path to the `dist` directory.

This way, when we use `include-media`, we can use `includePaths` option of `node-sass` (I don't know if it's available in ruby implementation). For example in a gulp task using `gulp-sass` : 

```javascript
var gulp = require('gulp');
var sass = require('gulp-sass');

gulp.task('styles', function() {
    gulp.src('main.scss')
        .pipe(sass({
            includePaths: [require('include-media').includePath]
        }))
        .pipe(gulp.dest('.'));
});
```

With this, in our `main.scss` file, we can include `include-media` by doing the following : 

```scss
@import 'include-media';
```

Instead of something like : 

```scss
@import 'node_modules/include-media/dist/include-media';
```