### PR TITLE
Add Eyeglass support

### DIFF
--- a/eyeglass-exports.js
+++ b/eyeglass-exports.js
@@ -1,0 +1,7 @@
+var path = require('path');
+
+module.exports = function(eyeglass, sass) {
+  return {
+    sassDir: path.join(__dirname, 'dist')
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,12 @@
     "url": "https://github.com/eduardoboucas/include-media/issues"
   },
   "homepage": "http://include-media.com",
+  "keywords": ["sass", "eyeglass-module"],
+  "eyeglass": {
+    "sassDir": "dist",
+    "exports": false,
+    "needs": "^0.6.0"
+  },
   "scripts": {
     "test": "gulp test",
     "lint": "scss-lint . --config ./.scss-lint.yml"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "eyeglass": {
     "sassDir": "dist",
     "exports": false,
-    "needs": "^0.6.0"
+    "needs": "^0.8.3"
   },
   "scripts": {
     "test": "gulp test",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,8 @@
   "homepage": "http://include-media.com",
   "keywords": ["sass", "eyeglass-module"],
   "eyeglass": {
-    "sassDir": "dist",
-    "exports": false,
-    "needs": "^0.8.3"
+    "exports": "eyeglass-exports.js",
+    "needs": "*"
   },
   "scripts": {
     "test": "gulp test",


### PR DESCRIPTION
Work for issue: #80 

Update package.json to turn it into a module discoverable by Eyeglass.

I've also create a test repository to ensure include-media is discoverable by Eyeglass and that a user can import the library using a simple `@import "include-media"`
https://github.com/nathanjessen/include-media-eyeglass-module