### PR TITLE
[RFR] Added an interval for empty unit

### DIFF
--- a/dist/_include-media.scss
+++ b/dist/_include-media.scss
@@ -84,7 +84,8 @@ $media-expressions: (
 $unit-intervals: (
   'px': 1,
   'em': 0.01,
-  'rem': 0.1
+  'rem': 0.1,
+  '': 0
 ) !default;
 
 ///

--- a/src/_config.scss
+++ b/src/_config.scss
@@ -64,7 +64,8 @@ $media-expressions: (
 $unit-intervals: (
   'px': 1,
   'em': 0.01,
-  'rem': 0.1
+  'rem': 0.1,
+  '': 0
 ) !default;
 
 ///


### PR DESCRIPTION
This PR allows media queries using unitless values, such as `aspect-ratio`:

```scss
.foo {
  @include media('aspect-ratio>1') {
    color: red;
  }
}
```

It would previously throw this error:

```
Unknown unit ``.
```

Ping @eduardoboucas.