### PR TITLE
Adds support for Spaces

### DIFF
--- a/dist/_include-media.scss
+++ b/dist/_include-media.scss
@@ -171,6 +171,26 @@ $im-no-media-breakpoint: 'desktop' !default;
 ///
 $im-no-media-expressions: ('screen', 'portrait', 'landscape') !default;
 
+///
+/// Find first char which is not a space
+///
+/// @param {String} $string - String to search
+/// @param {String} $direction ['left'] - Either 'left' or 'right' to indicate search direction
+///
+/// @return {Number} - Index of first non-space character
+///
+@function first-index($string, $direction: 'left') {
+  @for $i from 1 through str-length($string) {
+    $index: if($direction == 'left', $i, -$i);
+
+    @if str-slice($string, $index, $index) != ' ' {
+      @return $index;
+    }
+  }
+
+  @return 0;
+}
+
 ////
 /// Cross-engine logging engine
 /// @author Hugo Giraudel
@@ -322,7 +342,7 @@ $im-no-media-expressions: ('screen', 'portrait', 'landscape') !default;
 ///
 @function get-expression-value($expression, $operator) {
   $operator-index: str-index($expression, $operator);
-  $value: str-slice($expression, $operator-index + str-length($operator));
+  $value: trim(str-slice($expression, $operator-index + str-length($operator)));
 
   @if map-has-key($breakpoints, $value) {
     $value: map-get($breakpoints, $value);
@@ -467,6 +487,21 @@ $im-no-media-expressions: ('screen', 'portrait', 'landscape') !default;
   }
 
   @return $value * map-get($units, $unit);
+}
+
+///
+/// Trim's a string by removing leading and trailing spaces
+///
+/// @param {String} $string - String to trim
+///
+/// @return {String} - String without spaces
+///
+@function trim($string) {
+  @return str-slice(
+    $string,
+    first-index($string, 'left'),
+    first-index($string, 'right')
+  );
 }
 
 ///

--- a/src/helpers/_first-index.scss
+++ b/src/helpers/_first-index.scss
@@ -1,0 +1,19 @@
+///
+/// Find first char which is not a space
+///
+/// @param {String} $string - String to search
+/// @param {String} $direction ['left'] - Either 'left' or 'right' to indicate search direction
+///
+/// @return {Number} - Index of first non-space character
+///
+@function first-index($string, $direction: 'left') {
+  @for $i from 1 through str-length($string) {
+    $index: if($direction == 'left', $i, -$i);
+
+    @if str-slice($string, $index, $index) != ' ' {
+      @return $index;
+    }
+  }
+
+  @return 0;
+}

--- a/src/helpers/_parser.scss
+++ b/src/helpers/_parser.scss
@@ -71,7 +71,7 @@
 ///
 @function get-expression-value($expression, $operator) {
   $operator-index: str-index($expression, $operator);
-  $value: str-slice($expression, $operator-index + str-length($operator));
+  $value: trim(str-slice($expression, $operator-index + str-length($operator)));
 
   @if map-has-key($breakpoints, $value) {
     $value: map-get($breakpoints, $value);

--- a/src/helpers/_trim.scss
+++ b/src/helpers/_trim.scss
@@ -1,0 +1,14 @@
+///
+/// Trim's a string by removing leading and trailing spaces
+///
+/// @param {String} $string - String to trim
+///
+/// @return {String} - String without spaces
+///
+@function trim($string) {
+  @return str-slice(
+    $string,
+    first-index($string, 'left'),
+    first-index($string, 'right')
+  );
+}

--- a/tests/parse-expression.scss
+++ b/tests/parse-expression.scss
@@ -21,7 +21,12 @@ $tests-parse-expression: map-merge($media-expressions, (
   '>=desktop': '(min-width: 1024px)',
   '≥desktop': '(min-width: 1024px)',
   '<=desktop': '(max-width: 1024px)',
-  '≤desktop': '(max-width: 1024px)'
+  '≤desktop': '(max-width: 1024px)',
+
+
+  '> phone': '(min-width: 321px)',
+  '>= tablet': '(min-width: 768px)',
+  '≥ desktop': '(min-width: 1024px)'
 ));
 
 @include run(test('parse-expression', $tests-parse-expression));


### PR DESCRIPTION
Per [this tweet](https://twitter.com/HugoGiraudel/status/758394788450340864) it seems like there wasn't a conscious decision to not allow `op variable` syntax (for example `>= phone`) so I went ahead and took a pass at implementing it. Full credit to Hugo for the `trim` and `first-index` methods - I ripped them straight out of `sass-semver`. First time I've really done something intense in Sass, but gave it my best shot - please let me know if I broke styleguide somewhere 😄 