### PR TITLE
Update for iPhone 6 plus

### DIFF
--- a/dist/_include-media.scss
+++ b/dist/_include-media.scss
@@ -32,7 +32,7 @@
 ///  $breakpoints: ('phone': 320px);
 ///
 $breakpoints: (
-  'phone': 320px,
+  'phone': 414px,
   'tablet': 768px,
   'desktop': 1024px
 ) !default;


### PR DESCRIPTION
Modified phone breakpoint to 414px, as it was leaving behind the iPhone 6 plus breakpoint