### PR TITLE
Add a default operator

### DIFF
--- a/dist/_include-media.scss
+++ b/dist/_include-media.scss
@@ -171,6 +171,26 @@ $im-no-media-breakpoint: 'desktop' !default;
 ///
 $im-no-media-expressions: ('screen', 'portrait', 'landscape') !default;
 
+///
+/// Defines a default operator if none is provided to media()
+///
+/// @example scss - Default operator will be added to expression
+///  $im-default-operator: '>';
+///  @include media('tablet') {
+///    .foo {
+///      color: tomato;
+///    }
+///  }
+///
+///  /* Generates: */
+///  @media (max-width: 768px) {
+///    .foo {
+///      color: tomato;
+///    }
+///  }
+///
+$im-default-operator: '<' !default;
+
 ////
 /// Cross-engine logging engine
 /// @author Hugo Giraudel
@@ -269,12 +289,7 @@ $im-no-media-expressions: ('screen', 'portrait', 'landscape') !default;
     }
   }
 
-  // It is not possible to include a mixin inside a function, so we have to
-  // rely on the `im-log(..)` function rather than the `log(..)` mixin. Because
-  // functions cannot be called anywhere in Sass, we need to hack the call in
-  // a dummy variable, such as `$_`. If anybody ever raise a scoping issue with
-  // Sass 3.3, change this line in `@if im-log(..) {}` instead.
-  $_: im-log('No operator found in `#{$expression}`.');
+  @return '';
 }
 
 
@@ -365,6 +380,12 @@ $im-no-media-expressions: ('screen', 'portrait', 'landscape') !default;
   }
 
   $operator: get-expression-operator($expression);
+
+  @if $operator == '' {
+    $operator: $im-default-operator;
+    $expression: $operator + $expression;
+  }
+
   $dimension: get-expression-dimension($expression, $operator);
   $prefix: get-expression-prefix($operator);
   $value: get-expression-value($expression, $operator);

--- a/src/_config.scss
+++ b/src/_config.scss
@@ -150,3 +150,23 @@ $im-no-media-breakpoint: 'desktop' !default;
 ///  /* No output */
 ///
 $im-no-media-expressions: ('screen', 'portrait', 'landscape') !default;
+
+///
+/// Defines a default operator if none is provided to media()
+///
+/// @example scss - Default operator will be added to expression
+///  $im-default-operator: '>';
+///  @include media('tablet') {
+///    .foo {
+///      color: tomato;
+///    }
+///  }
+///
+///  /* Generates: */
+///  @media (min-width: 769px) {
+///    .foo {
+///      color: tomato;
+///    }
+///  }
+///
+$im-default-operator: '<' !default;

--- a/src/helpers/_parser.scss
+++ b/src/helpers/_parser.scss
@@ -19,12 +19,7 @@
     }
   }
 
-  // It is not possible to include a mixin inside a function, so we have to
-  // rely on the `im-log(..)` function rather than the `log(..)` mixin. Because
-  // functions cannot be called anywhere in Sass, we need to hack the call in
-  // a dummy variable, such as `$_`. If anybody ever raise a scoping issue with
-  // Sass 3.3, change this line in `@if im-log(..) {}` instead.
-  $_: im-log('No operator found in `#{$expression}`.');
+  @return '';
 }
 
 
@@ -115,6 +110,12 @@
   }
 
   $operator: get-expression-operator($expression);
+
+  @if $operator == '' {
+    $operator: $im-default-operator;
+    $expression: $operator + $expression;
+  }
+
   $dimension: get-expression-dimension($expression, $operator);
   $prefix: get-expression-prefix($operator);
   $value: get-expression-value($expression, $operator);

--- a/tests/helpers/_SassyTester.scss
+++ b/tests/helpers/_SassyTester.scss
@@ -52,7 +52,7 @@
   $tests: ();
 
   @each $arguments, $expected-result in $spec {
-    $actual-result: call($function, $arguments...);
+    $actual-result: call(get-function($function), $arguments...);
     $passed: $actual-result == $expected-result;
 
     $tests: append($tests, (

--- a/tests/parse-expression.scss
+++ b/tests/parse-expression.scss
@@ -2,6 +2,7 @@
 @import 'helpers/SassyTester';
 
 $tests-parse-expression: map-merge($media-expressions, (
+  'phone': '(max-width: 319px)',
   '>phone': '(min-width: 321px)',
   '<phone': '(max-width: 319px)',
   '>=phone': '(min-width: 320px)',
@@ -9,6 +10,7 @@ $tests-parse-expression: map-merge($media-expressions, (
   '<=phone': '(max-width: 320px)',
   '≤phone': '(max-width: 320px)',
 
+  'tablet': '(max-width: 767px)',
   '>tablet': '(min-width: 769px)',
   '<tablet': '(max-width: 767px)',
   '>=tablet': '(min-width: 768px)',
@@ -16,6 +18,7 @@ $tests-parse-expression: map-merge($media-expressions, (
   '<=tablet': '(max-width: 768px)',
   '≤tablet': '(max-width: 768px)',
 
+  'desktop': '(max-width: 1023px)',
   '>desktop': '(min-width: 1025px)',
   '<desktop': '(max-width: 1023px)',
   '>=desktop': '(min-width: 1024px)',


### PR DESCRIPTION
Added "<" as a default operator (#174).

So:

```
 @include media('tablet') {
   .foo {
     color: tomato;
   }
 }
```

Generates:

```
 @media (max-width: 767px) {
   .foo {
     color: tomato;
   }
 }
```