### PR TITLE
Add "sass" property in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test": "npm run lint && node tests/index.js",
     "lint": "scss-lint . --config ./.scss-lint.yml"
   },
+  "sass": "dist/_include-media.scss",
   "license": "MIT",
   "devDependencies": {
     "gh-pages": "^0.12.0",


### PR DESCRIPTION
This PR exposes the SCSS file in the `package.json` which allows tools like `node-sass` to find the correct file when used like this: `@import '~include-media';`.

For more details, see https://jaketrent.com/post/package-json-style-attribute/.

_CC @eduardoboucas, @HugoGiraudel_