### PR TITLE
Change em's unit interval from 0.1 to 0.0625. This is because some de…

### DIFF
--- a/dist/_include-media.scss
+++ b/dist/_include-media.scss
@@ -67,11 +67,11 @@ $media-expressions: (
 ///  /* Generates: */
 ///  @media (min-width: 129px) {}
 ///
-/// @example scss - Interval for ems is defined as `0.01` by default
+/// @example scss - Interval for ems is defined as `0.0625` by default
 ///  @include media('>20em') {}
 ///
 ///  /* Generates: */
-///  @media (min-width: 20.01em) {}
+///  @media (min-width: 20.0625em) {}
 ///
 /// @example scss - Interval for rems is defined as `0.1` by default, to be used with `font-size: 62.5%;`
 ///  @include media('>2.0rem') {}
@@ -81,7 +81,7 @@ $media-expressions: (
 ///
 $unit-intervals: (
   'px': 1,
-  'em': 0.01,
+  'em': 0.0625,
   'rem': 0.1,
   '': 0
 ) !default;

--- a/src/_config.scss
+++ b/src/_config.scss
@@ -49,11 +49,11 @@ $media-expressions: (
 ///  /* Generates: */
 ///  @media (min-width: 129px) {}
 ///
-/// @example scss - Interval for ems is defined as `0.01` by default
+/// @example scss - Interval for ems is defined as `0.0625` by default
 ///  @include media('>20em') {}
 ///
 ///  /* Generates: */
-///  @media (min-width: 20.01em) {}
+///  @media (min-width: 20.0625em) {}
 ///
 /// @example scss - Interval for rems is defined as `0.1` by default, to be used with `font-size: 62.5%;`
 ///  @include media('>2.0rem') {}
@@ -63,7 +63,7 @@ $media-expressions: (
 ///
 $unit-intervals: (
   'px': 1,
-  'em': 0.01,
+  'em': 0.0625,
   'rem': 0.1,
   '': 0
 ) !default;


### PR DESCRIPTION
Some devices like old iPads and iPad mini don't validate the breakpoints in ems correctly.

Hi guys,

I found this issue in a current project so I overwrote the $unit-intervals variable in my project. But I feel this might be something you guys will want to look at and maybe update.

When using pixels a '>tablet' is compiled as '>769px'. 

In ems, (768 / 16 = 48em) '>tablet' is complied as '>48.01em'. But 48.01em in pixels is 768.16px and not 769px. This is having in mind the default browser font size of 16px and html of 62.5% (10px).

The right value in ems should be '>48.0625em' which then converts to the expected value. This applies to any other em value so the interval should be 0.0625.

Any thoughts?

