### PR TITLE
add support for spacing between expressions

### DIFF
--- a/dist/_include-media.scss
+++ b/dist/_include-media.scss
@@ -290,6 +290,7 @@ $im-no-media-expressions: ('screen', 'portrait', 'landscape') !default;
 @function get-expression-dimension($expression, $operator) {
   $operator-index: string.index($expression, $operator);
   $parsed-dimension: string.slice($expression, 0, $operator-index - 1);
+  $parsed-dimension: str-trim($parsed-dimension);
   $dimension: 'width';
 
   @if string.length($parsed-dimension) > 0 {
@@ -321,11 +322,12 @@ $im-no-media-expressions: ('screen', 'portrait', 'landscape') !default;
 @function get-expression-value($expression, $operator) {
   $operator-index: string.index($expression, $operator);
   $value: string.slice($expression, $operator-index + string.length($operator));
+  $trimmedValue: str-trim($value);
 
-  @if map.has-key($breakpoints, $value) {
-    $value: map.get($breakpoints, $value);
+  @if map.has-key($breakpoints, $trimmedValue) {
+    $value: map.get($breakpoints, $trimmedValue);
   } @else {
-    $value: to-number($value);
+    $value: to-number($trimmedValue);
   }
 
   $interval: map.get($unit-intervals, math.unit($value));
@@ -490,6 +492,30 @@ $im-no-media-expressions: ('screen', 'portrait', 'landscape') !default;
   }
 
   @return $value * map.get($units, $unit);
+}
+
+////
+/// String to number converter
+/// @author Jack McNicol
+/// @access private
+////
+
+///
+/// Trims a string of leading and trailing spaces
+///
+/// @param {String} $string - Value to be trimmed
+///
+/// @return {String}
+///
+
+@function str-trim($string) {
+  @if (str-slice($string, 1, 1) == ' ') {
+    @return str-trim(str-slice($string, 2));
+  } @else if (str-slice($string, str-length($string), -1) == ' ') {
+    @return str-trim(str-slice($string, 1, -2));
+  } @else {
+    @return $string;
+  }
 }
 
 ///

--- a/src/helpers/_parser.scss
+++ b/src/helpers/_parser.scss
@@ -37,6 +37,7 @@
 @function get-expression-dimension($expression, $operator) {
   $operator-index: string.index($expression, $operator);
   $parsed-dimension: string.slice($expression, 0, $operator-index - 1);
+  $parsed-dimension: str-trim($parsed-dimension);
   $dimension: 'width';
 
   @if string.length($parsed-dimension) > 0 {
@@ -68,11 +69,12 @@
 @function get-expression-value($expression, $operator) {
   $operator-index: string.index($expression, $operator);
   $value: string.slice($expression, $operator-index + string.length($operator));
+  $trimmedValue: str-trim($value);
 
-  @if map.has-key($breakpoints, $value) {
-    $value: map.get($breakpoints, $value);
+  @if map.has-key($breakpoints, $trimmedValue) {
+    $value: map.get($breakpoints, $trimmedValue);
   } @else {
-    $value: to-number($value);
+    $value: to-number($trimmedValue);
   }
 
   $interval: map.get($unit-intervals, math.unit($value));

--- a/src/helpers/_trim.scss
+++ b/src/helpers/_trim.scss
@@ -1,0 +1,17 @@
+///
+/// Trims a string of leading and trailing spaces
+///
+/// @param {String} $string - Value to be trimmed
+///
+/// @return {String}
+///
+
+@function str-trim($string) {
+  @if (str-slice($string, 1, 1) == ' ') {
+    @return str-trim(str-slice($string, 2));
+  } @else if (str-slice($string, str-length($string), -1) == ' ') {
+    @return str-trim(str-slice($string, 1, -2));
+  } @else {
+    @return $string;
+  }
+}

--- a/test/functions/get-expression-dimension.scss
+++ b/test/functions/get-expression-dimension.scss
@@ -15,8 +15,18 @@
             dimension: 'width',
         )
         (
+            expression: ('>= 768px'),
+            operator: '>=',
+            dimension: 'width',
+        )
+        (
             expression: ('height>=1000px'),
             operator: '>=',
+            dimension: 'height',
+        )
+        (
+            expression: ('height > 100px'),
+            operator: '>',
             dimension: 'height',
         )
     );

--- a/test/functions/get-expression-value.scss
+++ b/test/functions/get-expression-value.scss
@@ -7,6 +7,10 @@
       '<phone': 319px,
       '<=desktop': 1024px,
       '>tablet': 769px,
+      '> tablet': 769px,
+      '< tablet': 767px,
+      'height > 100px': 101px,
+      'height < tablet': 767px,
     );
     @each $assert, $expect in $tests-get-expression-prefix {
         @include test('get-expression-value [#{$assert}]') {


### PR DESCRIPTION
A support for spacing between expressions

allows them to be written like

```scss
@include media("> desktop", "<= 1150px", "height > 100px") {
    font-size: 4.0rem;
}
```

Fixes https://github.com/eduardoboucas/include-media/issues/172