### PR TITLE
Fix Dart Sass deprecation warning - global built-in function str-leng…

### DIFF
--- a/dist/_include-media.scss
+++ b/dist/_include-media.scss
@@ -514,10 +514,10 @@ $im-no-media-expressions: ('screen', 'portrait', 'landscape') !default;
 ///
 
 @function str-trim($string) {
-  @if (str-slice($string, 1, 1) == ' ') {
-    @return str-trim(str-slice($string, 2));
-  } @else if (str-slice($string, str-length($string), -1) == ' ') {
-    @return str-trim(str-slice($string, 1, -2));
+  @if (string.slice($string, 1, 1) == ' ') {
+    @return str-trim(string.slice($string, 2));
+  } @else if (string.slice($string, string.length($string), -1) == ' ') {
+    @return str-trim(string.slice($string, 1, -2));
   } @else {
     @return $string;
   }

--- a/src/helpers/_trim.scss
+++ b/src/helpers/_trim.scss
@@ -13,10 +13,10 @@
 ///
 
 @function str-trim($string) {
-  @if (str-slice($string, 1, 1) == ' ') {
-    @return str-trim(str-slice($string, 2));
-  } @else if (str-slice($string, str-length($string), -1) == ' ') {
-    @return str-trim(str-slice($string, 1, -2));
+  @if (string.slice($string, 1, 1) == ' ') {
+    @return str-trim(string.slice($string, 2));
+  } @else if (string.slice($string, string.length($string), -1) == ' ') {
+    @return str-trim(string.slice($string, 1, -2));
   } @else {
     @return $string;
   }


### PR DESCRIPTION
Fix Dart Sass deprecation warning - global built-in function str-length and str-slice are deprecated, changed to string.length and string.slice.