### PR TITLE
fix if() function deprecation warnings in Dart Sass v1.95.0+

### DIFF
--- a/dist/_include-media.scss
+++ b/dist/_include-media.scss
@@ -263,7 +263,11 @@ $im-no-media-expressions: ('screen', 'portrait', 'landscape') !default;
 /// @return {String} - `min` or `max`
 ///
 @function get-expression-prefix($operator) {
-  @return if(list.index(('<', '<=', '≤'), $operator), 'max', 'min');
+  @if list.index(('<', '<=', '≤'), $operator) {
+    @return 'max';
+  } @else {
+    @return 'min';
+  }
 }
 
 ///
@@ -390,11 +394,16 @@ $im-no-media-expressions: ('screen', 'portrait', 'landscape') !default;
     $value: string.slice($value, 2);
   }
 
+  $sign: 1;
+  @if $minus {
+    $sign: -1;
+  }
+
   @for $i from 1 through string.length($value) {
     $character: string.slice($value, $i, $i);
 
     @if not(list.index(map.keys($numbers), $character) or $character == '.') {
-      @return to-length(if($minus, -$result, $result), string.slice($value, $i));
+      @return to-length($sign * $result, string.slice($value, $i));
     }
 
     @if $character == '.' {
@@ -407,7 +416,7 @@ $im-no-media-expressions: ('screen', 'portrait', 'landscape') !default;
     }
   }
 
-  @return if($minus, -$result, $result);
+  @return $sign * $result;
 }
 
 ///

--- a/src/helpers/_parser.scss
+++ b/src/helpers/_parser.scss
@@ -50,7 +50,11 @@
 /// @return {String} - `min` or `max`
 ///
 @function get-expression-prefix($operator) {
-  @return if(list.index(('<', '<=', '≤'), $operator), 'max', 'min');
+  @if list.index(('<', '<=', '≤'), $operator) {
+    @return 'max';
+  } @else {
+    @return 'min';
+  }
 }
 
 ///

--- a/src/helpers/_to-number.scss
+++ b/src/helpers/_to-number.scss
@@ -41,11 +41,16 @@
     $value: string.slice($value, 2);
   }
 
+  $sign: 1;
+  @if $minus {
+    $sign: -1;
+  }
+
   @for $i from 1 through string.length($value) {
     $character: string.slice($value, $i, $i);
 
     @if not(list.index(map.keys($numbers), $character) or $character == '.') {
-      @return to-length(if($minus, -$result, $result), string.slice($value, $i));
+      @return to-length($sign * $result, string.slice($value, $i));
     }
 
     @if $character == '.' {
@@ -58,7 +63,7 @@
     }
   }
 
-  @return if($minus, -$result, $result);
+  @return $sign * $result;
 }
 
 ///

--- a/test/functions/slice.scss
+++ b/test/functions/slice.scss
@@ -30,8 +30,14 @@
     @each $test in $test-slices {
         $assert: map.get($test, 'check');
         $expect: map.get($test, 'expect');
-        $start: if(map.has-key($test, 'start'), map.get($test, 'start'), 1);
-        $end: if(map.has-key($test, 'end'), map.get($test, 'end'), list.length(map.get($test, 'check')));
+        $start: 1;
+        @if map.has-key($test, 'start') {
+            $start: map.get($test, 'start');
+        }
+        $end: list.length(map.get($test, 'check'));
+        @if map.has-key($test, 'end') {
+            $end: map.get($test, 'end');
+        }
 
         @include test('slice [#{$assert}]') {
             $actual: slice($assert, $start, $end);


### PR DESCRIPTION
replaced deprecated if() function syntax with modern @if/@else blocks

closes #240